### PR TITLE
Circular import fix

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -24,7 +24,7 @@ ignore=CVS
 
 # Add files or directories matching the regex patterns to the ignore-list. The
 # regex matches against paths and can be in Posix or Windows format.
-ignore-paths=
+ignore-paths=backend/.venv
 
 # Files or directories matching the regex patterns are skipped. The regex
 # matches against base names, not paths.

--- a/.pylintrc
+++ b/.pylintrc
@@ -89,8 +89,7 @@ disable=raw-checker-failed,
         global-statement,
         invalid-name,
         too-many-lines,
-        too-many-arguments,
-        cyclic-import
+        too-many-arguments
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/backend/pingurl/__init__.py
+++ b/backend/pingurl/__init__.py
@@ -3,7 +3,6 @@
 import atexit
 from apscheduler.schedulers.background import BackgroundScheduler
 from flask import Flask
-from pingurl import watched_urls
 
 
 app = Flask(__name__)
@@ -11,4 +10,4 @@ scheduler = BackgroundScheduler(daemon=True)
 scheduler.start()
 
 # Shut down the scheduler when exiting the app
-atexit.register(scheduler.shutdown())
+atexit.register(scheduler.shutdown)

--- a/backend/pingurl/schedule.py
+++ b/backend/pingurl/schedule.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta, timezone
 from pingurl.ping import send_ping_persist_data
-from pingurl.watched_urls import WatchedUrl
+from pingurl.models import WatchedUrl
 from pingurl import scheduler as apscheduler
 
 jobs = {}


### PR DESCRIPTION
pingurl/__init__.py contained an import of watchedurls.py which imports
__init__.py itself, causing the program to crash.

Removing the line fixed this issue.

Also made sure that atexit.register has its argument as a callable.