### PR TITLE
fixed error 404-issue

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -89,7 +89,8 @@ disable=raw-checker-failed,
         global-statement,
         invalid-name,
         too-many-lines,
-        too-many-arguments
+        too-many-arguments,
+        unused-import
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.pylintrc
+++ b/.pylintrc
@@ -89,8 +89,7 @@ disable=raw-checker-failed,
         global-statement,
         invalid-name,
         too-many-lines,
-        too-many-arguments,
-        unused-import
+        too-many-arguments
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 """runs pingurl-app"""
 # No idea why, but putting watched_urls here fixed error 404-issue
-from pingurl import app, watched_urls
+from pingurl import app
+from pingurl import watched_urls  # pylint: disable=unused-import
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,5 +1,6 @@
 """runs pingurl-app"""
-from pingurl import app
+# No idea why, but putting watched_urls here fixed error 404-issue
+from pingurl import app, watched_urls
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,5 +1,4 @@
 """runs pingurl-app"""
-# No idea why, but putting watched_urls here fixed error 404-issue
 from pingurl import app
 from pingurl import watched_urls  # pylint: disable=unused-import
 


### PR DESCRIPTION
Fixat error 404. Nu går det lägga till watched_urls och sånt.


Ingen aning varför det fungerar dock. initiellt så importerades watched_urls i slutet av __init__-filen, men det gillade inte pylint. Hade därför flyttat importen till toppen av den filen, under alla andra imports som man ska göra. Det orsakade istället "cyclical import" som i sin tur krashade programmet vid uppstart. Det löstes genom att ta bort importen av watched_urls som fick programmet att fungera, men orsakade istället 404.

Hursomhelst, slutade med att jag testade flytta importen till app.py istället och där fungerar det. Behövde bara stänga av "unused-imports" i pylintrc.