### PR TITLE
added test for get_stats and fixed get_stats-function

### DIFF
--- a/backend/pingurl/persistance.py
+++ b/backend/pingurl/persistance.py
@@ -89,8 +89,8 @@ def add_ping_data(ping_data: PingData):
 def get_stats():
     """returns stats"""
     ping_count = 0
-    for url_id in pings.items():
-        ping_count += len(pings[url_id])
+    for ping_list in pings.items():
+        ping_count += len(ping_list)
 
     return {"watchedUrls": len(watched_urls), "pings": ping_count}
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,12 @@
+"""pytest configuration"""
+
+import pytest
+from pingurl import persistance
+
+
+@pytest.fixture(scope="function", autouse=True)
+def reset_persistance():
+    """Resets global variables between tests"""
+    persistance.pings = {}
+    persistance.watched_urls = {}
+    persistance.next_id = 0

--- a/backend/tests/test_persistance_business_ping_integration.py
+++ b/backend/tests/test_persistance_business_ping_integration.py
@@ -19,4 +19,23 @@ def test_added_url_in_get_urls():
     urls = persistance.get_url_ids()
     assert wu.url_id in urls
     assert pd.url_id in urls
-    
+
+
+def test_added_url_and_ping_in_get_stats():
+    """
+    Tests if persistance.get_stats() can receive
+    no. of urls and pings added from business.add_watched_url()
+    and ping.send_ping()
+    """
+
+    dt = datetime(2023, 11, 16, tzinfo=timezone.utc)
+    wu_list = [
+        WatchedUrl(dt, True, 1, "http://www.example.org"),
+        WatchedUrl(dt, True, 1, "http://www.example.org"),
+    ]
+    for wu in wu_list:
+        business.add_watched_url(wu)
+        pd = ping.send_ping(wu)
+        persistance.add_ping_data(pd)
+    stats = persistance.get_stats()
+    assert stats == {"watchedUrls": 2, "pings": 4}

--- a/backend/tests/test_persistance_business_ping_integration.py
+++ b/backend/tests/test_persistance_business_ping_integration.py
@@ -7,6 +7,18 @@ from pingurl import ping
 from pingurl.models import WatchedUrl
 
 
+# @pytest.fixture(scope="function", autouse=True)
+# def reset_persistance():
+#     """Resets global variables between tests"""
+#     pings_before = persistance.pings
+#     watched_urls_before = persistance.watched_urls
+#     next_id_before = persistance.next_id
+#     yield
+#     persistance.pings = pings_before
+#     persistance.watched_urls = watched_urls_before
+#     persistance.next_id = next_id_before
+
+
 def test_added_url_in_get_urls():
     """
     Tests if persistance.get_url_ids() can get

--- a/backend/tests/test_watched_urls.py
+++ b/backend/tests/test_watched_urls.py
@@ -1,14 +1,14 @@
 """Tests for pingurl/watched_urls.py"""
 from datetime import datetime, timezone
 import pytest
-from pingurl import models, business, watched_urls
+from pingurl import models, business, watched_urls, persistance
 from app import app
 
 
 obj = watched_urls
 
 
-@pytest.fixture(scope='function', name='flask_test')
+@pytest.fixture(scope="function", name="flask_test")
 def flask_test_client():
     """This is for mocktest of flask application"""
     with app.test_client() as client:
@@ -16,16 +16,18 @@ def flask_test_client():
 
 
 def test_get_watched_urls_err(flask_test):
-    """This is a mock test that send a get request to /watched-urls/0, 
+    """This is a mock test that send a get request to /watched-urls/0,
     should return error status_code = 404"""
-    response = flask_test.get('/watched-urls/0')
+    response = flask_test.get("/watched-urls/0")
     assert response.status_code == 404
 
 
 def test_get_watched_urls(flask_test):
-    """This is a mock test that sends a get request to /watched-urls/1, 
+    """This is a mock test that sends a get request to /watched-urls/1,
     since i added an url with id 1 it should return
     status code 200"""
+    persistance.next_id = 1
+
     url = "http://www.example.org"
     dt1 = datetime(2023, 1, 1, tzinfo=timezone.utc)
     new_url = models.WatchedUrl(dt1, True, 1, url)


### PR DESCRIPTION
Skapade test för persistance.get_stats() efter att man lagt till url via business.add_watched_url().
Fixade också till get_stats() då den var sönder.

Fömodligen har jag tidigare skrivt pings.items() blint för att pylint klagade. Hade inte anpassat koden efter detta..
Nu fungerar det. Efter att ha testat med pytest och debuggat, så har jag kommit fram till att den returnerar förväntad output.